### PR TITLE
Update task visibility in Habitica

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -72,14 +72,7 @@ class StateHabiticaCreated(FSMState):
 
 class StateHabiticaFinished(FSMState):
     def next_state(self) -> None:
-        try:
-            self.context.habitica.delete_task(self.generic_task.get_habitica_task_id())
-        except HTTPError as ex:
-            if ex.response is not None and ex.response.status_code == HTTPStatus.NOT_FOUND:
-                _LOGGER.warning(f"Habitica task '{self.generic_task.content}' not found.")
-            else:
-                raise ex
-
+        _LOGGER.info(f"Task '{self.generic_task.content}' marked as completed in Habitica.")
         self.context.delete_state(self.generic_task)
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -41,3 +41,27 @@ class TestGetTaskDifficulty:
         )
         labels = ["Urgent", "Important"]
         assert TasksSync._get_task_difficulty(settings, labels, TodoistPriority.P1) == HabiticaDifficulty.HARD
+
+
+class TestTaskCompletion:
+    @staticmethod
+    def should_not_delete_completed_tasks_in_habitica(mocker):
+        mocker.patch("habitica_api.HabiticaAPI.delete_task")
+        mocker.patch("habitica_api.HabiticaAPI.score_task")
+        mocker.patch("todoist_api.TodoistAPI.sync", return_value="2023-01-01T00:00:00Z")
+        mocker.patch("todoist_api.TodoistAPI.iter_pop_newly_completed_tasks", return_value=[
+            {
+                "item_object": {
+                    "content": "Test Task",
+                    "labels": [],
+                    "priority": 1,
+                }
+            }
+        ])
+
+        tasks_sync = TasksSync()
+        tasks_sync.run_forever()
+
+        habitica_api = tasks_sync.habitica
+        habitica_api.delete_task.assert_not_called()
+        habitica_api.score_task.assert_called_once()


### PR DESCRIPTION
Update `StateHabiticaFinished` class to log task completion instead of deleting tasks in Habitica.

* Remove the call to `delete_task` in the `StateHabiticaFinished` class in `src/main.py`.
* Add a log statement to indicate task completion in the `next_state` method of `StateHabiticaFinished` class in `src/main.py`.
* Add a test in `tests/unit/test_main.py` to ensure that completed tasks are not deleted in Habitica and are only marked as completed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/siddhero97/todoist-habitica-sync/pull/1?shareId=5dea1218-3e74-4da4-838d-44e8978995a9).