### PR TITLE
Fix task synchronization between Todoist and Habitica

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -157,6 +157,21 @@ class TasksSync:  # pylint: disable=too-few-public-methods
             self._task_cache.save_task(generic_task)
             self._log.info(f"'{generic_task.content}' -> {generic_task.state}")
 
+            # Log completed tasks
+            self._log.info(f"Completed task in Todoist: {todoist_completed_task.item_object.content}")
+
+            # Update Habitica with completed tasks
+            self.habitica.create_task(
+                todoist_completed_task.item_object.content,
+                self._get_task_difficulty(
+                    get_settings(),
+                    todoist_completed_task.item_object.labels,
+                    TodoistPriority(todoist_completed_task.item_object.priority),
+                ),
+            )
+            self.habitica.score_task(generic_task.get_habitica_task_id())
+            self.habitica.delete_task(generic_task.get_habitica_task_id())
+
         for generic_task in self._task_cache.in_progress_tasks():
             try:
                 state = FSMState.factory(self, generic_task)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -65,3 +65,88 @@ class TestTaskCompletion:
         habitica_api = tasks_sync.habitica
         habitica_api.delete_task.assert_not_called()
         habitica_api.score_task.assert_called_once()
+
+    @staticmethod
+    def should_log_completed_tasks(mocker):
+        mocker.patch("habitica_api.HabiticaAPI.create_task")
+        mocker.patch("habitica_api.HabiticaAPI.score_task")
+        mocker.patch("habitica_api.HabiticaAPI.delete_task")
+        mocker.patch("todoist_api.TodoistAPI.sync", return_value="2023-01-01T00:00:00Z")
+        mocker.patch("todoist_api.TodoistAPI.iter_pop_newly_completed_tasks", return_value=[
+            {
+                "item_object": {
+                    "content": "Test Task",
+                    "labels": [],
+                    "priority": 1,
+                }
+            }
+        ])
+        mock_logger = mocker.patch("main._LOGGER")
+
+        tasks_sync = TasksSync()
+        tasks_sync.run_forever()
+
+        mock_logger.info.assert_any_call("Completed task in Todoist: Test Task")
+
+    @staticmethod
+    def should_call_create_task_for_completed_tasks(mocker):
+        mocker.patch("habitica_api.HabiticaAPI.score_task")
+        mocker.patch("habitica_api.HabiticaAPI.delete_task")
+        mocker.patch("todoist_api.TodoistAPI.sync", return_value="2023-01-01T00:00:00Z")
+        mocker.patch("todoist_api.TodoistAPI.iter_pop_newly_completed_tasks", return_value=[
+            {
+                "item_object": {
+                    "content": "Test Task",
+                    "labels": [],
+                    "priority": 1,
+                }
+            }
+        ])
+        mock_create_task = mocker.patch("habitica_api.HabiticaAPI.create_task")
+
+        tasks_sync = TasksSync()
+        tasks_sync.run_forever()
+
+        mock_create_task.assert_called_once_with("Test Task", HabiticaDifficulty.TRIVIAL)
+
+    @staticmethod
+    def should_call_score_task_for_completed_tasks(mocker):
+        mocker.patch("habitica_api.HabiticaAPI.create_task")
+        mocker.patch("habitica_api.HabiticaAPI.delete_task")
+        mocker.patch("todoist_api.TodoistAPI.sync", return_value="2023-01-01T00:00:00Z")
+        mocker.patch("todoist_api.TodoistAPI.iter_pop_newly_completed_tasks", return_value=[
+            {
+                "item_object": {
+                    "content": "Test Task",
+                    "labels": [],
+                    "priority": 1,
+                }
+            }
+        ])
+        mock_score_task = mocker.patch("habitica_api.HabiticaAPI.score_task")
+
+        tasks_sync = TasksSync()
+        tasks_sync.run_forever()
+
+        mock_score_task.assert_called_once()
+
+    @staticmethod
+    def should_call_delete_task_for_completed_tasks(mocker):
+        mocker.patch("habitica_api.HabiticaAPI.create_task")
+        mocker.patch("habitica_api.HabiticaAPI.score_task")
+        mocker.patch("todoist_api.TodoistAPI.sync", return_value="2023-01-01T00:00:00Z")
+        mocker.patch("todoist_api.TodoistAPI.iter_pop_newly_completed_tasks", return_value=[
+            {
+                "item_object": {
+                    "content": "Test Task",
+                    "labels": [],
+                    "priority": 1,
+                }
+            }
+        ])
+        mock_delete_task = mocker.patch("habitica_api.HabiticaAPI.delete_task")
+
+        tasks_sync = TasksSync()
+        tasks_sync.run_forever()
+
+        mock_delete_task.assert_called_once()


### PR DESCRIPTION
Add logging and Habitica updates for completed tasks in Todoist.

* **src/main.py**
  - Log completed tasks in the `TasksSync._next_tasks_state` method.
  - Update the `TasksSync._next_tasks_state` method to call `HabiticaAPI.create_task` for completed tasks.
  - Update the `TasksSync._next_tasks_state` method to call `HabiticaAPI.score_task` for completed tasks.
  - Update the `TasksSync._next_tasks_state` method to call `HabiticaAPI.delete_task` for completed tasks.

* **tests/unit/test_main.py**
  - Add a test to verify that completed tasks are logged in the `TasksSync._next_tasks_state` method.
  - Add a test to verify that `HabiticaAPI.create_task` is called for completed tasks in the `TasksSync._next_tasks_state` method.
  - Add a test to verify that `HabiticaAPI.score_task` is called for completed tasks in the `TasksSync._next_tasks_state` method.
  - Add a test to verify that `HabiticaAPI.delete_task` is called for completed tasks in the `TasksSync._next_tasks_state` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/siddhero97/todoist-habitica-sync/pull/4?shareId=33728cd7-f85a-47b0-b47e-e56197ed80cb).