### PR TITLE
Fix ModuleNotFoundError: No module named 'pydantic' on Heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN python -m pip install --upgrade pip
 
 # Doesn't build consistently for armv7
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-RUN pip install "cryptography<3.5" poetry
+RUN pip install "cryptography<3.5" poetry pydantic
 
 COPY pyproject.toml poetry.lock ./
 


### PR DESCRIPTION
Add `pydantic` to the Dockerfile to ensure it is installed in the Docker image.

* Modify the `RUN pip install` command to include `pydantic`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/siddhero97/todoist-habitica-sync/pull/8?shareId=e8e9619d-d73f-44cc-bb60-1aabd06b9c03).